### PR TITLE
Some fixes which I discovered on course of testing with Std. Test Harness

### DIFF
--- a/oadrlib/lib/oadr2b/RegisterReport.cs
+++ b/oadrlib/lib/oadr2b/RegisterReport.cs
@@ -83,6 +83,15 @@ namespace oadrlib.lib.oadr2b
             request.requestID = requestID;
             request.venID = venID;
 
+            // Test case R1_3170_TH_VTN_1 (test-harness for OpenADR certification
+            // as provided by Quality logic) fails if reportRequestID is not set. 
+            // Report request ID is mandatory in OpenADR for any subsquent request 
+            // when sent for same report.
+            if (reportRequestID != null)
+            {
+                request.reportRequestID = reportRequestID;
+            }
+
             request.oadrReport = new oadrReportType[reports.Count];
 
             int index = 0;

--- a/oadrlib/lib/oadr2b/ReportWrapper.cs
+++ b/oadrlib/lib/oadr2b/ReportWrapper.cs
@@ -261,7 +261,9 @@ namespace oadrlib.lib.oadr2b
                 return report;
 
             List<IntervalType> reportIntervals = m_reportIntervals.Values.ToList().OrderBy(o => o.dtstart.datetime).ToList();
-            reportIntervals.Reverse();
+            // Test Case R1_3160_TH_VTN_1: Based on OpenADR specifications, intervals have to be              
+            // in ascending order. Reversing it here converts it into descending order.
+            //reportIntervals.Reverse();
 
             // the dtstart of the report must match the dtstart of the first interval
             report.dtstart = new dtstart();


### PR DESCRIPTION
Some fixes which I discovered on course of testing the Open ADR VEN client with Test Harness as provided by Quality Logic. Also, on debugging confirmed that Test harness is testing again correct OpenADR 2.0b standard.